### PR TITLE
Compatibility with Chat Heads

### DIFF
--- a/sources/Collective/1.19.2/Fabric/src/main/java/com/natamus/collective/fabric/mixin/ChatListenerMixin.java
+++ b/sources/Collective/1.19.2/Fabric/src/main/java/com/natamus/collective/fabric/mixin/ChatListenerMixin.java
@@ -17,41 +17,36 @@
 package com.natamus.collective.fabric.mixin;
 
 import com.natamus.collective.fabric.callbacks.CollectiveChatEvents;
-import net.minecraft.Util;
-import net.minecraft.client.GuiMessageTag;
-import net.minecraft.client.Minecraft;
 import net.minecraft.client.multiplayer.PlayerInfo;
 import net.minecraft.client.multiplayer.chat.ChatListener;
-import net.minecraft.client.multiplayer.chat.ChatTrustLevel;
 import net.minecraft.network.chat.*;
-import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.ModifyVariable;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
-import org.spongepowered.asm.mixin.injection.callback.LocalCapture;
 
-import javax.annotation.Nullable;
 import java.time.Instant;
 
 @Mixin(value = ChatListener.class, priority = 1001)
 public abstract class ChatListenerMixin {
-    @Shadow private @Final Minecraft minecraft;
-    @Shadow private long previousMessageTime;
-    @Shadow protected abstract void narrateChatMessage(ChatType.Bound bound, Component component);
-    @Shadow protected abstract void logPlayerMessage(PlayerChatMessage playerChatMessage, ChatType.Bound bound, @Nullable PlayerInfo playerInfo, ChatTrustLevel chatTrustLevel);
+    @Unique ChatType.Bound collective$bound;
+    @Unique PlayerInfo collective$playerInfo;
 
-    @Inject(method = "showMessageToPlayer", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/Gui;getChat()Lnet/minecraft/client/gui/components/ChatComponent;"), cancellable = true, locals = LocalCapture.CAPTURE_FAILSOFT)
-    public void showMessageToPlayer(ChatType.Bound bound, PlayerChatMessage playerChatMessage, Component component, PlayerInfo playerInfo, boolean bl, Instant instant, CallbackInfoReturnable<Boolean> cir, ChatTrustLevel chatTrustLevel, GuiMessageTag guiMessageTag, MessageSignature messageSignature, FilterMask filterMask) {
-        //Component newMessage = CollectiveChatEvents.CLIENT_CHAT_RECEIVED.invoker().onClientChat(bound.chatType(), component, playerInfo.getProfile().getId());
-        Component newMessage = CollectiveChatEvents.CLIENT_CHAT_RECEIVED.invoker().onClientChat(bound.chatType(), component, (playerInfo != null ? playerInfo.getProfile().getId() : null));
-		if (component != newMessage) {
-            this.minecraft.gui.getChat().addMessage(newMessage, messageSignature, guiMessageTag);
-            this.narrateChatMessage(bound, playerChatMessage.serverContent());
-            this.logPlayerMessage(playerChatMessage, bound, playerInfo, chatTrustLevel);
-            this.previousMessageTime = Util.getMillis();
-            cir.setReturnValue(true);
-		}
+    @Inject(method = "showMessageToPlayer", at = @At("HEAD"))
+    public void captureParams(ChatType.Bound bound, PlayerChatMessage playerChatMessage, Component component, PlayerInfo playerInfo, boolean bl, Instant instant, CallbackInfoReturnable<Boolean> cir) {
+        collective$bound = bound;
+        collective$playerInfo = playerInfo;
+    }
+
+    @ModifyVariable(method = "showMessageToPlayer", at = @At("HEAD"), argsOnly = true)
+    public Component modifyMessage(Component component) {
+        try {
+            return CollectiveChatEvents.CLIENT_CHAT_RECEIVED.invoker().onClientChat(collective$bound.chatType(), component, (collective$playerInfo != null ? collective$playerInfo.getProfile().getId() : null));
+        } finally {
+            collective$bound = null;
+            collective$playerInfo = null;
+        }
     }
 }

--- a/sources/Collective/1.19.4/Fabric/src/main/java/com/natamus/collective/fabric/mixin/ChatListenerMixin.java
+++ b/sources/Collective/1.19.4/Fabric/src/main/java/com/natamus/collective/fabric/mixin/ChatListenerMixin.java
@@ -18,39 +18,37 @@ package com.natamus.collective.fabric.mixin;
 
 import com.mojang.authlib.GameProfile;
 import com.natamus.collective.fabric.callbacks.CollectiveChatEvents;
-import net.minecraft.Util;
-import net.minecraft.client.GuiMessageTag;
-import net.minecraft.client.Minecraft;
 import net.minecraft.client.multiplayer.chat.ChatListener;
-import net.minecraft.client.multiplayer.chat.ChatTrustLevel;
-import net.minecraft.network.chat.*;
-import org.spongepowered.asm.mixin.Final;
+import net.minecraft.network.chat.ChatType;
+import net.minecraft.network.chat.Component;
+import net.minecraft.network.chat.PlayerChatMessage;
 import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.ModifyVariable;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
-import org.spongepowered.asm.mixin.injection.callback.LocalCapture;
 
 import java.time.Instant;
 
 @Mixin(value = ChatListener.class, priority = 1001)
 public abstract class ChatListenerMixin {
-    @Shadow private @Final Minecraft minecraft;
-    @Shadow private long previousMessageTime;
-    @Shadow protected abstract void narrateChatMessage(ChatType.Bound bound, Component component);
-    @Shadow protected abstract void logPlayerMessage(PlayerChatMessage playerChatMessage, ChatType.Bound bound, GameProfile gameProfile, ChatTrustLevel chatTrustLevel);
-    @Shadow protected abstract boolean showMessageToPlayer(ChatType.Bound bound, PlayerChatMessage playerChatMessage, Component component, GameProfile gameProfile, boolean bl, Instant instant);
+    @Unique ChatType.Bound collective$bound;
+    @Unique GameProfile collective$gameProfile;
 
-    @Inject(method = "showMessageToPlayer", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/Gui;getChat()Lnet/minecraft/client/gui/components/ChatComponent;"), cancellable = true, locals = LocalCapture.CAPTURE_FAILSOFT)
-    public void showMessageToPlayer(ChatType.Bound bound, PlayerChatMessage playerChatMessage, Component component, GameProfile gameProfile, boolean bl, Instant instant, CallbackInfoReturnable<Boolean> cir, ChatTrustLevel chatTrustLevel, GuiMessageTag guiMessageTag, MessageSignature messageSignature, FilterMask filterMask) {
-        Component newMessage = CollectiveChatEvents.CLIENT_CHAT_RECEIVED.invoker().onClientChat(bound.chatType(), component, (gameProfile != null ? gameProfile.getId() : null));
-		if (component != newMessage) {
-            this.minecraft.gui.getChat().addMessage(newMessage, messageSignature, guiMessageTag);
-            this.narrateChatMessage(bound, playerChatMessage.decoratedContent());
-            this.logPlayerMessage(playerChatMessage, bound, gameProfile, chatTrustLevel);
-            this.previousMessageTime = Util.getMillis();
-            cir.setReturnValue(true);
-		}
+    @Inject(method = "showMessageToPlayer", at = @At("HEAD"))
+    public void captureParams(ChatType.Bound bound, PlayerChatMessage playerChatMessage, Component component, GameProfile gameProfile, boolean bl, Instant instant, CallbackInfoReturnable<Boolean> cir) {
+        collective$bound = bound;
+        collective$gameProfile = gameProfile;
+    }
+
+    @ModifyVariable(method = "showMessageToPlayer", at = @At("HEAD"), argsOnly = true)
+    public Component modifyMessage(Component component) {
+        try {
+            return CollectiveChatEvents.CLIENT_CHAT_RECEIVED.invoker().onClientChat(collective$bound.chatType(), component, (collective$gameProfile != null ? collective$gameProfile.getId() : null));
+        } finally {
+            collective$bound = null;
+            collective$gameProfile = null;
+        }
     }
 }

--- a/sources/Collective/1.20.1/Fabric/src/main/java/com/natamus/collective/fabric/mixin/ChatListenerMixin.java
+++ b/sources/Collective/1.20.1/Fabric/src/main/java/com/natamus/collective/fabric/mixin/ChatListenerMixin.java
@@ -18,38 +18,37 @@ package com.natamus.collective.fabric.mixin;
 
 import com.mojang.authlib.GameProfile;
 import com.natamus.collective.fabric.callbacks.CollectiveChatEvents;
-import net.minecraft.Util;
-import net.minecraft.client.GuiMessageTag;
-import net.minecraft.client.Minecraft;
 import net.minecraft.client.multiplayer.chat.ChatListener;
-import net.minecraft.client.multiplayer.chat.ChatTrustLevel;
-import net.minecraft.network.chat.*;
-import org.spongepowered.asm.mixin.Final;
+import net.minecraft.network.chat.ChatType;
+import net.minecraft.network.chat.Component;
+import net.minecraft.network.chat.PlayerChatMessage;
 import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.ModifyVariable;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
-import org.spongepowered.asm.mixin.injection.callback.LocalCapture;
 
 import java.time.Instant;
 
 @Mixin(value = ChatListener.class, priority = 1001)
 public abstract class ChatListenerMixin {
-    @Shadow private @Final Minecraft minecraft;
-    @Shadow private long previousMessageTime;
-    @Shadow protected abstract void narrateChatMessage(ChatType.Bound bound, Component component);
-    @Shadow protected abstract void logPlayerMessage(PlayerChatMessage playerChatMessage, ChatType.Bound bound, GameProfile gameProfile, ChatTrustLevel chatTrustLevel);
-    @Shadow protected abstract boolean showMessageToPlayer(ChatType.Bound bound, PlayerChatMessage playerChatMessage, Component component, GameProfile gameProfile, boolean bl, Instant instant);
+    @Unique ChatType.Bound collective$bound;
+    @Unique GameProfile collective$gameProfile;
 
-    @Inject(method = "showMessageToPlayer", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/Gui;getChat()Lnet/minecraft/client/gui/components/ChatComponent;"), cancellable = true, locals = LocalCapture.CAPTURE_FAILSOFT)
-    public void showMessageToPlayer(ChatType.Bound bound, PlayerChatMessage playerChatMessage, Component component, GameProfile gameProfile, boolean bl, Instant instant, CallbackInfoReturnable<Boolean> cir, ChatTrustLevel chatTrustLevel, GuiMessageTag guiMessageTag, MessageSignature messageSignature, FilterMask filterMask) {
-            Component newMessage = CollectiveChatEvents.CLIENT_CHAT_RECEIVED.invoker().onClientChat(bound.chatType(), component, (gameProfile != null ? gameProfile.getId() : null));		if (component != newMessage) {
-            this.minecraft.gui.getChat().addMessage(newMessage, messageSignature, guiMessageTag);
-            this.narrateChatMessage(bound, playerChatMessage.decoratedContent());
-            this.logPlayerMessage(playerChatMessage, bound, gameProfile, chatTrustLevel);
-            this.previousMessageTime = Util.getMillis();
-            cir.setReturnValue(true);
-		}
+    @Inject(method = "showMessageToPlayer", at = @At("HEAD"))
+    public void captureParams(ChatType.Bound bound, PlayerChatMessage playerChatMessage, Component component, GameProfile gameProfile, boolean bl, Instant instant, CallbackInfoReturnable<Boolean> cir) {
+        collective$bound = bound;
+        collective$gameProfile = gameProfile;
+    }
+
+    @ModifyVariable(method = "showMessageToPlayer", at = @At("HEAD"), argsOnly = true)
+    public Component modifyMessage(Component component) {
+        try {
+            return CollectiveChatEvents.CLIENT_CHAT_RECEIVED.invoker().onClientChat(collective$bound.chatType(), component, (collective$gameProfile != null ? collective$gameProfile.getId() : null));
+        } finally {
+            collective$bound = null;
+            collective$gameProfile = null;
+        }
     }
 }

--- a/sources/Collective/1.20.2/Fabric/src/main/java/com/natamus/collective/fabric/mixin/ChatListenerMixin.java
+++ b/sources/Collective/1.20.2/Fabric/src/main/java/com/natamus/collective/fabric/mixin/ChatListenerMixin.java
@@ -18,38 +18,37 @@ package com.natamus.collective.fabric.mixin;
 
 import com.mojang.authlib.GameProfile;
 import com.natamus.collective.fabric.callbacks.CollectiveChatEvents;
-import net.minecraft.Util;
-import net.minecraft.client.GuiMessageTag;
-import net.minecraft.client.Minecraft;
 import net.minecraft.client.multiplayer.chat.ChatListener;
-import net.minecraft.client.multiplayer.chat.ChatTrustLevel;
-import net.minecraft.network.chat.*;
-import org.spongepowered.asm.mixin.Final;
+import net.minecraft.network.chat.ChatType;
+import net.minecraft.network.chat.Component;
+import net.minecraft.network.chat.PlayerChatMessage;
 import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.ModifyVariable;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
-import org.spongepowered.asm.mixin.injection.callback.LocalCapture;
 
 import java.time.Instant;
 
 @Mixin(value = ChatListener.class, priority = 1001)
 public abstract class ChatListenerMixin {
-    @Shadow private @Final Minecraft minecraft;
-    @Shadow private long previousMessageTime;
-    @Shadow protected abstract void narrateChatMessage(ChatType.Bound bound, Component component);
-    @Shadow protected abstract void logPlayerMessage(PlayerChatMessage playerChatMessage, ChatType.Bound bound, GameProfile gameProfile, ChatTrustLevel chatTrustLevel);
-    @Shadow protected abstract boolean showMessageToPlayer(ChatType.Bound bound, PlayerChatMessage playerChatMessage, Component component, GameProfile gameProfile, boolean bl, Instant instant);
+    @Unique ChatType.Bound collective$bound;
+    @Unique GameProfile collective$gameProfile;
 
-    @Inject(method = "showMessageToPlayer", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/Gui;getChat()Lnet/minecraft/client/gui/components/ChatComponent;"), cancellable = true, locals = LocalCapture.CAPTURE_FAILSOFT)
-    public void showMessageToPlayer(ChatType.Bound bound, PlayerChatMessage playerChatMessage, Component component, GameProfile gameProfile, boolean bl, Instant instant, CallbackInfoReturnable<Boolean> cir, ChatTrustLevel chatTrustLevel, GuiMessageTag guiMessageTag, MessageSignature messageSignature, FilterMask filterMask) {
-            Component newMessage = CollectiveChatEvents.CLIENT_CHAT_RECEIVED.invoker().onClientChat(bound.chatType(), component, (gameProfile != null ? gameProfile.getId() : null));		if (component != newMessage) {
-            this.minecraft.gui.getChat().addMessage(newMessage, messageSignature, guiMessageTag);
-            this.narrateChatMessage(bound, playerChatMessage.decoratedContent());
-            this.logPlayerMessage(playerChatMessage, bound, gameProfile, chatTrustLevel);
-            this.previousMessageTime = Util.getMillis();
-            cir.setReturnValue(true);
-		}
+    @Inject(method = "showMessageToPlayer", at = @At("HEAD"))
+    public void captureParams(ChatType.Bound bound, PlayerChatMessage playerChatMessage, Component component, GameProfile gameProfile, boolean bl, Instant instant, CallbackInfoReturnable<Boolean> cir) {
+        collective$bound = bound;
+        collective$gameProfile = gameProfile;
+    }
+
+    @ModifyVariable(method = "showMessageToPlayer", at = @At("HEAD"), argsOnly = true)
+    public Component modifyMessage(Component component) {
+        try {
+            return CollectiveChatEvents.CLIENT_CHAT_RECEIVED.invoker().onClientChat(collective$bound.chatType(), component, (collective$gameProfile != null ? collective$gameProfile.getId() : null));
+        } finally {
+            collective$bound = null;
+            collective$gameProfile = null;
+        }
     }
 }


### PR DESCRIPTION
From https://github.com/dzwdz/chat_heads/issues/76

The cancelable injects were skipping modified code, thus not allowing Chat Heads to find the owner of a chat message.
I replaced them with a compatible `@ModifyVariable` and added some fields to pass the needed parameters to it (`captureParams` runs before `modifyMessage`). This also eliminates the duplicated Minecraft code.
(Sidenote: This pattern breaks if the code is executed on different threads, in which case it would need to use `ThreadLocal`s, but this is not the case here.)

All versions tested working and compatible with Chat Heads.

P.S.
While testing I found Beautified Chat Client doesn't work with NoChatReports. I think this was 1.20.1 but it probably affects other versions too. It will just show the default chat format.